### PR TITLE
fix: declare optional solid-js peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -165,7 +165,13 @@
 		"typescript": "^5.1.6"
 	},
 	"peerDependencies": {
+		"solid-js": ">=1.0.0",
 		"typescript": ">=3.5.1"
+	},
+	"peerDependenciesMeta": {
+		"solid-js": {
+			"optional": true
+		}
 	},
 	"bin": {
 		"typesafe-i18n": "cli/typesafe-i18n.mjs"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,6 +7,10 @@ settings:
 importers:
 
   .:
+    dependencies:
+      solid-js:
+        specifier: '>=1.0.0'
+        version: 1.7.9
     devDependencies:
       '@size-limit/preset-small-lib':
         specifier: ^8.2.6
@@ -1799,7 +1803,6 @@ packages:
 
   /csstype@3.1.2:
     resolution: {integrity: sha512-I7K1Uu0MBPzaFKg4nI5Q7Vs2t+3gWWW648spaF+Rg7pI9ds18Ugn+lvg4SHczUdKlHI5LWBXyqfS8+DufyBsgQ==}
-    dev: true
 
   /data-uri-to-buffer@4.0.1:
     resolution: {integrity: sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==}
@@ -3211,7 +3214,6 @@ packages:
   /seroval@0.5.1:
     resolution: {integrity: sha512-ZfhQVB59hmIauJG5Ydynupy8KHyr5imGNtdDhbZG68Ufh1Ynkv9KOYOAABf71oVbQxJ8VkWnMHAjEHE7fWkH5g==}
     engines: {node: '>=10'}
-    dev: true
 
   /shebang-command@2.0.0:
     resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
@@ -3287,7 +3289,6 @@ packages:
     dependencies:
       csstype: 3.1.2
       seroval: 0.5.1
-    dev: true
 
   /source-map-js@1.0.2:
     resolution: {integrity: sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==}


### PR DESCRIPTION
## Problem

The root package exports `typesafe-i18n/solid`, and that adapter imports `solid-js` at runtime. The published 5.27.1 manifest only declares TypeScript as a peer, so strict or isolated package layouts cannot resolve the adapter's runtime import.

In a Bun project with `linker = "isolated"`, the unpatched package fails in three paths:

- `bun -e "await import('typesafe-i18n/solid')"` reports that it cannot find `solid-js` from the isolated `typesafe-i18n` package path.
- `node --input-type=module -e "await import('typesafe-i18n/solid')"` fails with `ERR_MODULE_NOT_FOUND` for `solid-js`.
- Vite 8.0.11's production build fails after 841 transformed modules because Rolldown cannot resolve `solid-js` from `typesafe-i18n/solid/index.mjs`.

Vite's development dependency optimization can hide the invalid package graph. The direct imports and production build expose it. [bjesuiter/bgf-wlan-translation-v5#211](https://github.com/bjesuiter/bgf-wlan-translation-v5/issues/211) has the consuming-project context and full comparison.

## Fix

Declare `solid-js >=1.0.0` as an optional peer dependency in the published root manifest. Solid adapter users must provide Solid, while users of the runtime or other adapters should not have to install it. The existing `typescript >=3.5.1` peer remains unchanged.

This is a manifest-only change. The repository has no package-manifest test seam, so I checked the packed artifact and installed that exact tarball in a fresh consumer instead of adding a new test framework.

## Validation

- [x] `pnpm install --frozen-lockfile`
- [x] `pnpm lint`
- [x] `pnpm test`
- [x] `pnpm build`
- [x] `npm pack --dry-run --json`
- [x] Packed-manifest assertion for the `./solid` export, both peer dependencies, and `peerDependenciesMeta.solid-js.optional`
- [x] Fresh Bun 1.4.2 install with `linker = "isolated"` from the exact tarball
- [x] Direct Bun import from the installed tarball
- [x] Direct Node 26.8.1 ESM import from the installed tarball
- [x] Vite 8.3.0 production build from the installed tarball

`pnpm test:size` also ran. It exceeded nearly every existing limit by 1 to 5 bytes, including unrelated runtime and framework entries. This patch changes package metadata only and cannot change those bundles, so I did not alter the limits.
